### PR TITLE
Create 0520-watchguard_decoders.xml

### DIFF
--- a/ruleset/decoders/0520-watchguard_decoders.xml
+++ b/ruleset/decoders/0520-watchguard_decoders.xml
@@ -1,0 +1,165 @@
+<!--
+These decoders are designed to work with the IBM LEEF format, this format is selectable on your Watchguard firewall.
+Created by Simon. V
+-->
+
+
+<decoder name="Watchguard">
+  <prematch>|WatchGuard|</prematch>
+</decoder>
+
+<decoder name="watchguard-son">
+  <parent>Watchguard</parent>
+  <regex type="pcre2">duration=(\w+)</regex>
+  <order>duration</order>
+</decoder>
+
+<decoder name="watchguard-son">
+  <parent>Watchguard</parent>
+  <regex type="pcre2">sent_bytes=(\w+)</regex>
+  <order>sent_bytes</order>
+</decoder>
+
+<decoder name="watchguard-son">
+  <parent>Watchguard</parent>
+  <regex type="pcre2">rcvd_bytes=(\w+)</regex>
+  <order>rcvd_bytes</order>
+</decoder>
+
+<decoder name="watchguard-son">
+  <parent>Watchguard</parent>
+  <regex type="pcre2">msg=([a-zA-Z0-9-()@.,= ]+)</regex>
+  <order>data</order>
+</decoder>
+
+<decoder name="watchguard-son">
+  <parent>Watchguard</parent>
+  <regex type="pcre2">(\w+)@Firebox-DB.+from.(\d+.\d+.\d+.\d+).(.+$)</regex>
+  <order>dstuser, srcip,  extra_data</order>
+</decoder>
+
+<decoder name="watchguard-son">
+  <parent>Watchguard</parent>
+  <regex type="pcre2">(\d\d:\d\d:\d\d)</regex>
+  <order>time</order>
+</decoder>
+
+<decoder name="watchguard-son">
+  <parent>Watchguard</parent>
+  <regex type="pcre2">ip_len=(\S+)</regex>
+  <order>ip_len</order>
+</decoder>
+
+<decoder name="watchguard-son">
+  <parent>Watchguard</parent>
+  <regex type="pcre2">ip_TTL=(\S+)</regex>
+  <order>ip_TTL</order>
+</decoder>
+
+<decoder name="watchguard-son">
+  <parent>Watchguard</parent>
+  <regex type="pcre2">tcp_offset=(\S+)</regex>
+  <order>tcp_offset</order>
+</decoder>
+
+<decoder name="watchguard-son">
+  <parent>Watchguard</parent>
+  <regex type="pcre2">tcp_flag=(\S+)</regex>
+  <order>tcp_flag</order>
+</decoder>
+
+<decoder name="watchguard-son">
+  <parent>Watchguard</parent>
+  <regex type="pcre2">tcp_seq=(\S+)</regex>
+  <order>tcp_seq</order>
+</decoder>
+
+<decoder name="watchguard-son">
+  <parent>Watchguard</parent>
+  <regex type="pcre2">tcp_window=(\S+)</regex>
+  <order>tcp_window</order>
+</decoder>
+
+<decoder name="watchguard-son">
+  <parent>Watchguard</parent>
+  <regex type="pcre2">in_if=(\S+)</regex>
+  <order>in_if</order>
+</decoder>
+
+<decoder name="watchguard-son">
+  <parent>Watchguard</parent>
+  <regex type="pcre2">out_if=(\S+)</regex>
+  <order>out_if</order>
+</decoder>
+
+<decoder name="watchguard-son">
+  <parent>Watchguard</parent>
+  <regex type="pcre2">policy=([a-zA-Z0-9-_ ]+)</regex>
+  <order>policy</order>
+</decoder>
+
+<decoder name="watchguard-son">
+  <parent>Watchguard</parent>
+  <regex type="pcre2">devTime=(\S+\s\S+\s\S+)</regex>
+  <order>date</order>
+</decoder>
+
+<decoder name="watchguard-son">
+  <parent>Watchguard</parent>
+  <regex type="pcre2">sys_name=(\S+)</regex>
+  <order>sys_name</order>
+</decoder>
+
+<decoder name="watchguard-son">
+  <parent>Watchguard</parent>
+  <regex type="pcre2">\|(\d{8})\|</regex>
+  <order>id</order>
+</decoder>
+
+<decoder name="watchguard-son">
+  <parent>Watchguard</parent>
+  <regex type="pcre2">src=(\S+)</regex>
+  <order>srcip</order>
+</decoder>
+
+<decoder name="watchguard-son">
+  <parent>Watchguard</parent>
+  <regex type="pcre2">srcPort=(\S+)</regex>
+  <order>srcport</order>
+</decoder>
+
+<decoder name="watchguard-son">
+  <parent>Watchguard</parent>
+  <regex type="pcre2">srcPort=(\S+)</regex>
+  <order>srcport</order>
+</decoder>
+
+<decoder name="watchguard-son">
+  <parent>Watchguard</parent>
+  <regex type="pcre2">dst=(\S+)</regex>
+  <order>dstip</order>
+</decoder>
+
+<decoder name="watchguard-son">
+  <parent>Watchguard</parent>
+  <regex type="pcre2">dstPostNAT=(\S+)</regex>
+  <order>dstip</order>
+</decoder>
+
+<decoder name="watchguard-son">
+  <parent>Watchguard</parent>
+  <regex type="pcre2">dstPort=(\S+)</regex>
+  <order>dstport</order>
+</decoder>
+
+<decoder name="watchguard-son">
+  <parent>Watchguard</parent>
+  <regex type="pcre2">disp=(\S+)</regex>
+  <order>action</order>
+</decoder>
+
+<decoder name="watchguard-son">
+  <parent>Watchguard</parent>
+  <regex type="pcre2">proto=(\S+)</regex>
+  <order>protocol</order>
+</decoder>


### PR DESCRIPTION
|Related issue|
|---|
||

<!--
This template reflects sections that must be included in new Pull requests.
Contributions from the community are really appreciated. If this is the case, please add the
"contribution" to properly track the Pull Request.

Please fill the table above. Feel free to extend it at your convenience.
-->

## Description

There were no decoders for the Watchguard firewall logs

## Configuration options

Select LEEF format on the firewall for the logs

## Logs/Alerts example

**Traffic :**
```
LEEF:1.0|WatchGuard|XTM|12.5.4.B622768|30000148|sys_name=T10	devTimeFormat=MMM dd yyyy HH:mm:ss Z	devTime=Mar 19 2021 13:17:46 +0100	policy=Honeypot-Port_Forward-00	disp=Allow	in_if=0-External	out_if=2-DMZ	ip_len=52	ip_TTL=116	proto=tcp	src=45.154.4.235	srcPort=49563	dst=192.168.240.40	dstPort=5900	dstPostNAT=10.0.2.11	tcp_offset=8	tcp_flag=S	tcp_seq=3098669628	tcp_window=8192
LEEF:1.0|WatchGuard|XTM|12.5.4.B622768|30000148|sys_name=T10	devTimeFormat=MMM dd yyyy HH:mm:ss Z	devTime=Mar 19 2021 13:30:03 +0100	policy=Unhandled External Packet-00	disp=Deny	in_if=0-External	out_if=Firebox	ip_len=30	ip_TTL=238	proto=icmp	src=192.172.226.11	srcPort=0	dst=192.168.240.40	dstPort=0
LEEF:1.0|WatchGuard|XTM|12.5.4.B622768|30000148|sys_name=T10	devTimeFormat=MMM dd yyyy HH:mm:ss Z	devTime=Mar 19 2021 13:30:07 +0100	policy=dmz-any-to-external-00	disp=Allow	in_if=2-DMZ	out_if=0-External	ip_len=60	ip_TTL=62	proto=tcp	src=10.0.2.11	srcPort=60694	srcPostNAT=192.168.240.40	dst=160.44.201.156	dstPort=443	tcp_offset=10	tcp_flag=S	tcp_seq=2856580878	tcp_window=64240
```

**Credentials :**
```
LEEF:1.0|WatchGuard|XTM|12.5.4.B622768|3E000002|sys_name=T10	devTimeFormat=MMM dd yyyy HH:mm:ss Z	devTime=Mar 19 2021 13:17:38 +0100	msg=Management user admin@Firebox-DB from 10.0.1.5 logged in
```

## Tests

<!--
Depending on the affected components by this PR, the following checks should be selected and marked.
-->

<!-- Minimum checks required -->
- Compilation without warnings in every supported platform
  - [x] Linux
  - [ ] Windows
  - [ ] MAC OS X
- [x] Source installation
- [ ] Package installation
- [ ] Source upgrade
- [ ] Package upgrade
- [ ] Review logs syntax and correct language
- [ ] QA templates contemplate the added capabilities

<!-- Depending on the affected OS -->
- Memory tests for Linux
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Valgrind (memcheck and descriptor leaks check)
  - [ ] Dr. Memory
  - [ ] AddressSanitizer
- Memory tests for Windows
  - [ ] Scan-build report
  - [ ] Coverity
  - [ ] Dr. Memory
- Memory tests for macOS
  - [ ] Scan-build report
  - [ ] Leaks
  - [ ] AddressSanitizer

<!-- Checks for huge PRs that affect the product more generally -->
- [ ] Retrocompatibility with older Wazuh versions
- [ ] Working on cluster environments
- [ ] Configuration on demand reports new parameters
- [ ] The data flow works as expected (agent-manager-api-app)
- [ ] Added unit tests (for new features)
- [ ] Stress test for affected components
